### PR TITLE
Add libmongo-client rosdep for Nix

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3768,6 +3768,7 @@ libmongoclient-dev:
   rhel:
     '7': [mongo-cxx-driver-devel]
   ubuntu: [libmongoclient-dev]
+  nixos: [libmongo-client]
 libmotif-dev:
   arch: [lesstif]
   debian: [libmotif-dev]


### PR DESCRIPTION
Step to fix https://github.com/lopsided98/nix-ros-overlay/issues/295